### PR TITLE
Implement id mapper cache

### DIFF
--- a/trololo/app.py
+++ b/trololo/app.py
@@ -101,6 +101,36 @@ Available commands are:
                 self._datamapper.save()
             print(os.linesep.join(out))
 
+        def show_board_map(args):
+            """
+            Display the entire board map.
+
+            :param args:
+            :return:
+            """
+            board_id = self._datamapper.take_from(self._datamapper.get_id_by_name(args.display), "boards")
+            out = []
+            ofs = " " * 4
+            for board in self._client.get_boards(board_id):
+                out.extend(["{}".format(board.name), "=" * len(board.name)])
+                lists = board.get_lists()
+                if lists:
+                    out.append(" \\__")
+                for list in lists:
+                    out.extend(["", "{}{}".format(ofs, list.name), "{}{}".format(ofs, "-" * len(list.name))])
+                    cards = list.get_cards()
+                    if cards:
+                        out.append(" {}\\__".format(ofs))
+                    for card in cards:
+                        out.append("{}### {}".format(ofs * 2, card.name))
+                        actions = card.get_actions()
+                        if actions:
+                            out.append(" {}\\__".format(ofs * 2))
+                        for action in actions:
+                            out.append("{}- {}".format(ofs * 3, action.get_text()))
+                out.append("")
+            print(os.linesep.join(out))
+
         parser = argparse.ArgumentParser(description="operations with the boards")
         parser.add_argument("-s", "--show", help="show available boards", action="store_true")
         parser.add_argument("-f", "--format", help="choose what format to display",
@@ -122,20 +152,7 @@ Available commands are:
         elif args.add:
             raise NotImplementedError("Want to add boards? Edward would happily accept your PR on Trololo! :-P")
         elif args.display:
-            board_id = self._datamapper.take_from(self._datamapper.get_id_by_name(args.display), "boards")
-            out = []
-            for board in self._client.get_boards(board_id):
-                out.append("{}".format(board.name))
-                out.append(" \\__")
-                for list in board.get_lists():
-                    out.append("  {}".format(list.name))
-                    out.append("   \\__")
-                    for card in list.get_cards():
-                        out.append("    {}".format(card.name))
-                        out.append("     \\__")
-                        for action in card.get_actions():
-                            out.append("      {}".format(action.get_text()))
-            print(os.linesep.join(out))
+            show_board_map(args)
         else:
             parser.print_help()
 

--- a/trololo/exceptions.py
+++ b/trololo/exceptions.py
@@ -25,3 +25,9 @@ class CLIError(Exception):
     """
     CLI error
     """
+
+
+class DataMapperError(Exception):
+    """
+    Error of the data mapper
+    """

--- a/trololo/idmapper.py
+++ b/trololo/idmapper.py
@@ -78,7 +78,7 @@ class TrololoIdMapper(object):
         :param action:
         :return:
         """
-        self.__datamap["actions"].setdefault(action.name, set()).add(action.id)
+        self.__datamap["actions"].setdefault(action.get_text(), set()).add(action.id)
 
     def is_id(self, text):
         """

--- a/trololo/idmapper.py
+++ b/trololo/idmapper.py
@@ -1,0 +1,135 @@
+"""
+A very simple helper to operate Trello data by strings,
+instead of remembering those cumbersome IDs.
+"""
+
+import pickle
+import os
+
+import trololo.exceptions
+from trololo.lalala import TrololoBoard, TrololoAction, TrololoLabel, TrololoCard, TrololoList
+
+
+class TrololoIdMapper(object):
+    """
+    Keeps on the disk what we already know.
+    """
+
+    DATA_MAPPER_FILE = "edward.bin"
+
+    def __init__(self, path):
+        """
+        Path to the mapper storage.
+
+        :param path:
+        """
+        self.__datamap = {
+            "boards": {},
+            "lists": {},
+            "cards": {},
+            "labels": {},
+            "actions": {},
+        }
+        self.__path = os.path.join(path, self.DATA_MAPPER_FILE)
+
+    def add_board(self, board: TrololoBoard) -> None:
+        """
+        Add board
+
+        :param board:
+        :return:
+        """
+        self.__datamap["boards"].setdefault(board.name, set()).add(board.id)
+
+    def add_list(self, t_list: TrololoList) -> None:
+        """
+        Add list
+
+        :param t_list:
+        :return:
+        """
+        self.__datamap["lists"].setdefault(t_list.name, set()).add(t_list.id)
+
+    def add_card(self, card: TrololoCard) -> None:
+        """
+        Add card
+
+        :param card:
+        :return:
+        """
+        self.__datamap["cards"].setdefault(card.name, set()).add(card.id)
+
+    def add_label(self, label: TrololoLabel) -> None:
+        """
+        Add label
+
+        :param label:
+        :return:
+        """
+        self.__datamap["labels"].setdefault(label.name, set()).add(label.id)
+
+    def add_action(self, action: TrololoAction) -> None:
+        """
+        Add action
+
+        :param action:
+        :return:
+        """
+        self.__datamap["actions"].setdefault(action.name, set()).add(action.id)
+
+    def get_id_by_name(self, text):
+        """
+        Lookup data mapper for the text occurrences and find
+        out what kind of IDs possibly can be there. Search
+        works only from starting with or entire string.
+
+        This is not super-optimal solution, but does the job.
+
+        :param text:
+        :return:
+        """
+        try:
+            int(text, 16)
+            is_id = True
+        except (ValueError, TypeError):
+            is_id = False
+
+        found = False
+        ret = dict(zip(list(self.__datamap.keys()) + ["id"], [set() for _ in range(len(self.__datamap))]))
+        if not is_id:
+            for section in self.__datamap:
+                for txt, ids in section.items():
+                    if txt.startswith(text):
+                        ret[section].update(ids)
+                        found = True
+        else:
+            ret["id"].add(text)
+
+        if not found:
+            raise trololo.exceptions.DataMapperError("No corresponding ID has been found.")
+
+        return ret
+
+    def save(self):
+        """
+        Save data map to the disk.
+
+        :return:
+        """
+        try:
+            with open(self.__path, "w") as dmh:
+                pickle.dump(dmh, self.__datamap)
+        except Exception as ex:
+            raise trololo.exceptions.DataMapperError("Error while saving data map: {}".format(ex))
+
+    def load(self):
+        """
+        Load data map from the disk.
+
+        :return:
+        """
+        try:
+            with open(self.__path, "r") as dmh:
+                self.__datamap = pickle.load(dmh)
+        except Exception as ex:
+            raise trololo.exceptions.DataMapperError("Error while loading data map: {}".format(ex))

--- a/trololo/idmapper.py
+++ b/trololo/idmapper.py
@@ -136,17 +136,19 @@ class TrololoIdMapper(object):
         """
         return (search_result.get("id") or search_result[section] or set(' ')).pop().strip()
 
-    def save(self):
+    def save(self, skip=False):
         """
         Save data map to the disk.
 
+        :param skip: Helper to avoid check every time if there is something to save.
         :return:
         """
-        try:
-            with open(self.__path, "wb") as dmh:
-                pickle.dump(self.__datamap, dmh)
-        except Exception as ex:
-            raise trololo.exceptions.DataMapperError("Error while saving data map: {}".format(ex))
+        if not skip:
+            try:
+                with open(self.__path, "wb") as dmh:
+                    pickle.dump(self.__datamap, dmh)
+            except Exception as ex:
+                raise trololo.exceptions.DataMapperError("Error while saving data map: {}".format(ex))
 
     def load(self):
         """

--- a/trololo/lalala.py
+++ b/trololo/lalala.py
@@ -156,7 +156,7 @@ class TrololoList(TrololoObject):
             "keepFromSource": "all",
             "name": name,
             "desc": description,
-            "pos": 0xffff,
+            "pos": "top",
         }
 
         return TrololoCard.load(self._client, self._client._request("cards", query=query, method="POST"))

--- a/trololo/lalala.py
+++ b/trololo/lalala.py
@@ -13,12 +13,26 @@ class TrololoObject(object):
     _re_gr = re.compile(r"(.)([A-Z][a-z]+)")
     _re_sb = re.compile(r"([a-z0-9])([A-Z])")
 
-    __attrs__ = []
-
     def __init__(self, client, **kwargs):
         self._client = client
-        for attr in self.__attrs__:
-            setattr(self, self._uncamel(attr), kwargs.get(attr))
+        self.__to_obj(kwargs)
+
+    def __to_obj(self, data, obj=None):
+        """
+        JSON to object.
+
+        :param data:
+        :param obj:
+        :return:
+        """
+        if obj is None:
+            obj = self
+        for key, value in data.items():
+            if isinstance(value, dict):
+                setattr(obj, key, type(key, (), {}))
+                self.__to_obj(value, getattr(obj, key))
+            else:
+                setattr(obj, key, value)
 
     def _uncamel(self, name):
         """
@@ -44,14 +58,12 @@ class TrololoLabel(TrololoObject):
     """
     Trello label on the board.
     """
-    __attrs__ = ["id", "color", "name"]
 
 
 class TrololoAction(TrololoObject):
     """
     Trello comment (action).
     """
-    __attrs__ = ["id", "type", "date", "data"]
 
     def get_text(self):
         """
@@ -59,14 +71,13 @@ class TrololoAction(TrololoObject):
 
         :return:
         """
-        return self.data.get("text", "* empty *")
+        return self.data.text
 
 
 class TrololoCard(TrololoObject):
     """
     Trello card on the trello list of the board.
     """
-    __attrs__ = ["id", "name", "url", "desc", "shortUrl", "dateLastActivity", "closed"]
 
     def get_actions(self):
         """
@@ -113,7 +124,6 @@ class TrololoList(TrololoObject):
     """
     Trello list on the trello Board.
     """
-    __attrs__ = ["id", "name", "closed", "idBoard"]
 
     def get_cards(self):
         """
@@ -156,7 +166,6 @@ class TrololoBoard(TrololoObject):
     """
     Trello Board.
     """
-    __attrs__ = ["id", "name", "desc", "shortUrl", "url", "dateLastView", "lists"]
 
     def get_lists(self):
         """

--- a/trololo/lalala.py
+++ b/trololo/lalala.py
@@ -115,9 +115,10 @@ class TrololoCard(TrololoObject):
                 id_labels.append(label.id)
             elif isinstance(label, str):
                 id_labels.append(label)
-        obj = self._client._request("cards/{}".format(self.id), query={"idLabels": ",".join(id_labels)}, method="PUT")
 
-        return obj
+        return TrololoLabel.load(self._client, self._client._request("cards/{}".format(self.id),
+                                                                     query={"idLabels": ",".join(id_labels)},
+                                                                     method="PUT"))
 
 
 class TrololoList(TrololoObject):


### PR DESCRIPTION
Implements ID mapper. Normally, things are added/viewed by Trello ID, which is a hash number (checksum). Mapper allows to keep relation between `object.name` and `object.id` and look up in reverse.

**Limitation:** Same `name` of the object might refer to different `object.id`. This is not implemented to overcome. In this case, use just plain IDs instead.